### PR TITLE
chore: update test & composer for laravel framework 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,24 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.14.1",
-        "illuminate/console": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0"
+        "php": "^8.3",
+        "spatie/laravel-package-tools": "^1.15",
+        "illuminate/console": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/database": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8|^8.1",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.20",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "laravel/pint": "^1.14",
+        "nunomaduro/collision": "^7.8 || ^8.1",
+        "nunomaduro/larastan": "^2.4",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "pestphp/pest": "^2.31",
+        "pestphp/pest-plugin-arch": "^2.1",
+        "pestphp/pest-plugin-laravel": "^2.5",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-deprecation-rules": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/tests/BadgeTest.php
+++ b/tests/BadgeTest.php
@@ -12,7 +12,8 @@ use Maize\Badges\Tests\Support\Badges\TrueProgressableBadge;
 use Maize\Badges\Tests\Support\Models\Team;
 use Maize\Badges\Tests\Support\Models\User;
 
-it('should give badges', function (HasBadges $model) {
+it('should give badges', function (Closure $modelFactory) {
+    $model = $modelFactory();
     expect($model->giveBadge(TrueBadge::class))
         ->not()->toBeNull()
         ->and($model->giveBadge(FalseBadge::class))
@@ -22,9 +23,10 @@ it('should give badges', function (HasBadges $model) {
         ->and(FalseBadge::giveTo($model))
         ->toBeNull();
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should give progressable badges', function (HasBadges $model) {
     expect($model->giveBadge(TrueProgressableBadge::class))
@@ -36,9 +38,10 @@ it('should give progressable badges', function (HasBadges $model) {
         ->and(FalseProgressableBadge::giveTo($model))
         ->toBeNull();
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should check if model has badge', function (HasBadges $model) {
     $model->giveBadge(TrueBadge::class);
@@ -47,9 +50,10 @@ it('should check if model has badge', function (HasBadges $model) {
         $model->hasBadge(TrueBadge::class)
     )->toBeTrue();
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should retrieve badge metadata', function (HasBadges $model) {
     $badge = $model->giveBadge(TrueBadge::class);
@@ -63,9 +67,10 @@ it('should retrieve badge metadata', function (HasBadges $model) {
         ->and(TrueBadge::getMetadata('name'))
         ->toBe('True Badge');
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should retrieve all awarded badges', function (HasBadges $model) {
     $model->giveBadge(TrueBadge::class);
@@ -75,18 +80,20 @@ it('should retrieve all awarded badges', function (HasBadges $model) {
         ->toHaveCount(2)
         ->toContainOnlyInstancesOf(BadgeModel::class);
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should sync badges', function (HasBadges $model) {
     expect($model->syncBadges())
         ->toHaveCount(2)
         ->toContainOnlyInstancesOf(BadgeModel::class);
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should delete badges on model delete', function (HasBadges $model) {
     $model->syncBadges();
@@ -94,9 +101,10 @@ it('should delete badges on model delete', function (HasBadges $model) {
 
     expect(BadgeModel::count())->toBe(0);
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
+
 
 it('should fire event on badge awarded', function (HasBadges $model) {
     \Illuminate\Support\Facades\Event::fake();
@@ -111,8 +119,8 @@ it('should fire event on badge awarded', function (HasBadges $model) {
         }
     );
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);
 
 it('should clear old badges', function (HasBadges $model) {
@@ -124,6 +132,6 @@ it('should clear old badges', function (HasBadges $model) {
 
     expect($model->badges)->toBeEmpty();
 })->with([
-    ['model' => fn () => User::factory()->create()],
-    ['model' => fn () => Team::factory()->create()],
+    [fn () => User::factory()->create()],
+    [fn () => Team::factory()->create()],
 ]);


### PR DESCRIPTION
Upgrade Description
This update adds full compatibility with PHP 8.3 and Laravel 12.

In addition, the test suite has been refactored to remove deprecated usage of named arguments in Pest’s data providers. This change ensures future compatibility with PHPUnit 11, which will no longer support named arguments in data-driven tests.

Summary of changes:
Require PHP ^8.3

Allow illuminate/* dependencies for Laravel ^10.0 || ^11.0 || ^12.0

Update orchestra/testbench for Laravel 12 compatibility

Upgrade pest, pest-plugin-laravel, and related dev tools to latest compatible versions

Refactor Pest tests:

Replaced deprecated named argument syntax in ->with() calls

Injected model factories via closures to ensure forward compatibility with PHPUnit 11